### PR TITLE
Include icon in portlet archetypes

### DIFF
--- a/archetypes/vaadin-archetype-liferay-portlet-sharedlib/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/vaadin-archetype-liferay-portlet-sharedlib/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -49,6 +49,12 @@
 				<include>**/liferay-plugin-package.properties</include>
 			</includes>
 		</fileSet>
+		<fileSet filtered="false">
+			<directory>src/main/webapp</directory>
+			<includes>
+				<include>icon.png</include>
+			</includes>
+		</fileSet>
 		<fileSet filtered="true">
 			<directory />
 			<includes>

--- a/archetypes/vaadin-archetype-liferay-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/vaadin-archetype-liferay-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -61,6 +61,12 @@
 				<include>**/*.scss</include>
 			</includes>
 		</fileSet>
+		<fileSet filtered="false">
+			<directory>src/main/webapp</directory>
+			<includes>
+				<include>icon.png</include>
+			</includes>
+		</fileSet>
 		<fileSet filtered="true">
 			<directory />
 			<includes>


### PR DESCRIPTION
While working on this archetype integration into Liferay IDE, I noticed the icon.png was not being copied during archetype creation, so sending in a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/maven-integration/1)
<!-- Reviewable:end -->
