### PR TITLE
chore: bumping enforcer version from 3.0.0 to 3.3.0 

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,7 +131,7 @@
     <profile>
       <id>release</id>
       <properties>
-        <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
+        <maven.enforcer.plugin.version>3.3.0</maven.enforcer.plugin.version>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
         <nexus.staging.maven.plugin.version>1.6.13</nexus.staging.maven.plugin.version>
         <staging.server.id>vaadin-staging</staging.server.id>


### PR DESCRIPTION
## Description

Bumping the enforcer version from 3.0.0 to 3.3.0. 

As 3.0.0 can cause validation errors for flow build:
- https://bender.vaadin.com/buildConfiguration/FlowRelease/401105?buildTab=log&focusLine=0&logView=flowAware

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed a self-review and correct misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
